### PR TITLE
Fix iOS WebGL refraction effect compatibility

### DIFF
--- a/sources/Experience/Materials/BlackHoleDistortionActiveMaterial.js
+++ b/sources/Experience/Materials/BlackHoleDistortionActiveMaterial.js
@@ -6,8 +6,7 @@ import fragmentShader from '../shaders/blackHoleDistortionActive/fragment.glsl'
 function BlackHoleDistortionActiveMaterial()
 {
     const material = new THREE.RawShaderMaterial({
-        glslVersion: THREE.GLSL3,
-        side: THREE.DoubleSide,
+glslVersion: THREE.GLSL1,        side: THREE.DoubleSide,
         // blending: THREE.AdditiveBlending,
         // depthWrite: false,
         // depthTest: false,

--- a/sources/Experience/shaders/blackHoleDistortionActive/fragment.glsl
+++ b/sources/Experience/shaders/blackHoleDistortionActive/fragment.glsl
@@ -3,8 +3,7 @@ precision highp int;
 
 in vec2 vUv;
 
-layout(location = 0) out vec4 pc_FragColor;
-
+out vec4 gl_FragColor;
 float inverseLerp(float v, float minValue, float maxValue)
 {
     return (v - minValue) / (maxValue - minValue);
@@ -27,5 +26,4 @@ void main()
 
     float strength = radialStrength;
     // pc_FragColor.r = strength;
-    pc_FragColor = vec4(strength, 1.0, 1.0, 1.0);
-}
+gl_FragColor = vec4(strength, 1.0, 1.0, 1.0);}


### PR DESCRIPTION
## Problem
The WebGL refraction effect was not working on iOS devices (iPad and iPhone with iOS 16.5 or earlier) because the material was using GLSL 3.0, which is not fully supported on iOS WebKit's WebGL implementation.

## Solution
This PR addresses the compatibility issue by:

1. **Changed GLSL version**: Updated `BlackHoleDistortionActiveMaterial.js` to use `THREE.GLSL1` instead of `THREE.GLSL3` for better compatibility with iOS Safari.

2. **Updated fragment shader**: Modified the fragment shader to use GLSL ES 1.0 compatible syntax:
   - Removed `layout(location = 0)` qualifier which is not supported in GLSL ES 1.0
   - Changed `pc_FragColor` to `gl_FragColor` which is the standard fragment output variable in GLSL ES 1.0

## Testing
Please test on iOS devices with Safari to confirm the refraction effect now displays correctly.

Fixes #1